### PR TITLE
VT-9: Extract DDS from TXM TXV using Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _tmp/
 logs/
 *.log
 config.json
+.python-version
 
 # Virtual Envs
 env/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _*Requires HyoutaTools._
 _**Refer to Known Issues_
 
 ## Requirements
-- Python 3.6+
+- Python 3.8+
 - Windows 7 SP1 or newer (for HyoutaTools)
 
 ## Running VesperiaTools

--- a/constants/tales.py
+++ b/constants/tales.py
@@ -20,6 +20,7 @@ UNPACKED_LEFTOVER_FILES = (
 # Note 1: PC identifier differs with 360 version.
 # Note 2: The PS4/XBO Definitive Edition should share the same identifier?
 # Note 3: Haven't check for PS3 and Switch DE.
+# TODO: Find a better way to identify TXV files
 TYPE_2_EXT_PC = {
     "00040000": ".ANM",
     "00000500": ".BLD",
@@ -33,6 +34,8 @@ TYPE_2_EXT_PC = {
     "54525348": ".TER",
     "00020000": ".TXM",
     "00155094": ".TXV",
+    "00014094": ".TXV",
+    "00055094": ".TXV",
 }
 
 
@@ -110,3 +113,6 @@ VERTEX_FORMAT_UV_CHANNEL_COUNT_MASK = bit(0) + bit(1)  # Vertex Stream format fl
 PLATFORM_X360 = 0x4
 PLATFORM_PC = 0x10
 TYPE_CODE = 0x00010000
+
+# Textures
+DDS_HEADER = b'\x44\x44\x53\x20\x7C'

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from PySide2.QtWidgets import *
 from constants.path import CONFIG_JSON
 from constants.ui import GITHUB_REPO_URL
 from utils.exporter import (
+    export_dds_textures,
     export_wavefront_mtl,
     export_wavefront_obj,
 )
@@ -97,9 +98,10 @@ class MainWindow(QWidget):
         self.txm_txv_browser_btn.setText("...")
         self.txm_txv_browser_btn.clicked.connect(
             partial(
-                self.browse_folder,
+                self.browse_file,
                 self.txm_txv_path_lineedit,
                 "Path to TXM/TXV files",
+                "TXM/TXV Files (*.txm *.txv)",
             )
         )
         self.txm_txv_layout.addWidget(self.txm_txv_browser_btn)
@@ -318,15 +320,17 @@ class MainWindow(QWidget):
             lineedit.setText(os.path.normpath(folder_path))
 
     def run_extract_textures(self):
-        if not self.hyouta_path_lineedit.text() or not self.txm_txv_path_lineedit.text():
+        txm_txv_path = self.txm_txv_path_lineedit.text()
+        if not txm_txv_path:
             QMessageBox.warning(
                 self,
                 "Warning",
-                "Ensure both HyoutaToolsCLI.exe and TXV/TXV paths are selected before extracting!",
+                "Ensure TXV/TXV path are selected before extracting!",
             )
             return
         self.update_config_json()
-        extract_textures(self.txm_txv_path_lineedit.text())
+        output_path, _ = os.path.split(txm_txv_path)
+        export_dds_textures(txm_txv_path, output_path)
 
     def run_unpack_dat(self):
         if not self.hyouta_path_lineedit.text() or not self.dat_path_lineedit.text():

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,2 +1,3 @@
 -r base.txt
 isort==5.7.0
+ipython==7.22.0

--- a/utils/exporter.py
+++ b/utils/exporter.py
@@ -14,6 +14,7 @@ from utils.meshes import (
     face_creation,
     write_to_obj,
 )
+from utils.textures import write_to_dds
 
 logger = logging.getLogger(__name__)
 
@@ -59,10 +60,10 @@ def join_mtl_files(mtl_files_path: str, mtl_name: str = None):
 
 
 def export_wavefront_mtl(
-    input_path: str,
-    output_path: str,
-    node: Node = None,
-    verbose=False,
+        input_path: str,
+        output_path: str,
+        node: Node = None,
+        verbose=False,
 ):
     node = Node() if node is None else node
     parse_material(input_path, node, verbose=False)
@@ -175,3 +176,14 @@ def export_wavefront_obj(
         "msg": "Successfully joined OBJs as all.obj",
         "exported_obj_path": exported_obj_path,
     })
+
+
+def export_dds_textures(
+        input_path: str,
+        output_path: str,
+        node: Node = None,
+        verbose=False,
+):
+    node = Node() if node is None else node
+    parse_textures(input_path, node, verbose=False)
+    write_to_dds(node, output_path)

--- a/utils/textures.py
+++ b/utils/textures.py
@@ -2,9 +2,11 @@
 import logging
 import os
 import subprocess
+from pathlib import Path
 
 from utils.files import unpack_dat
 from utils.helpers import get_path
+from parsers.parser import Node
 
 logger = logging.getLogger(__name__)
 
@@ -57,3 +59,20 @@ def extract_textures(package_path: str):
         )
     else:
         logger.info(f"Extract DDS textures completed. Found {found_txm_txv} TXM/TXV pairing files.")
+
+
+def write_to_dds(node: Node, output_path: str):
+    output_path = Path(output_path)
+    output_path.mkdir(exist_ok=True)
+
+    if node.name != 'NONAME':
+        output_path = output_path / node.name
+
+    for image in node.data["image_list"]:
+        texture_name = image["texture_name"]
+        texture_path = output_path / texture_name
+        dds_content = image["dds_content"]
+        with open(texture_path, 'wb') as dds_file:
+            dds_file.write(dds_content)
+
+    logger.info("Writing DDS textures completed.")


### PR DESCRIPTION
Replace HyoutaTools' `Tales.Vesperia.Texture.Decode` with Szkaradek123's Python implementation.

- Use the actual texture filename without the extra prefix padding generated with HyoutaTools.
- Bump Python requirements to 3.8+ for iPython library. Should still work with 3.6+ as iPython >7 requires Python 3.7+. Does not impact normal usage and iPython is strictly for dev testing.

